### PR TITLE
Add edge traffic signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
    * CHANGED: refactor to make valhalla/filesystem functionally redundant [#5319](https://github.com/valhalla/valhalla/pull/5319)
    * ADDED: Distribute C++ executables for Windows Python bindings [#5348](https://github.com/valhalla/valhalla/pull/5348)
    * ADDED: Distribute C++ executables for OSX Python bindings [#5301](https://github.com/valhalla/valhalla/pull/5301)
+   * ADDED: Add option `edge.traffic_signal` to trace attributes []()
 
 ## Release Date: 2024-10-10 Valhalla 3.5.1
 * **Removed**

--- a/docs/docs/api/map-matching/api-reference.md
+++ b/docs/docs/api/map-matching/api-reference.md
@@ -117,6 +117,7 @@ edge.truck_speed
 edge.truck_route
 edge.country_crossing
 edge.forward
+edge.traffic_signal
 
 // Node filter keys
 node.intersecting_edge.begin_heading
@@ -224,7 +225,7 @@ Each `edge` may include:
 | `landmarks` | List of landmarks along the edge. They are used as direction support in navigation. |                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `country_crossing` | True if the edge is a country crossing. |                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `forward` | True if the edge is traversed forwards and False if it is traversed backwards with respect to the reference shape/geometry (ie. the direction in which it was digitized). |
-
+| `traffic_signal` | True if the edge contains a traffic signal in its direction. |
 
 #### Sign items
 

--- a/proto/trip.proto
+++ b/proto/trip.proto
@@ -215,6 +215,7 @@ message TripLeg {
     }
     repeated Level levels = 61;
     uint32 level_precision = 62;
+    bool traffic_signal = 63;
   }
 
   message IntersectingEdge {

--- a/src/baldr/attributes_controller.cc
+++ b/src/baldr/attributes_controller.cc
@@ -85,6 +85,7 @@ const std::unordered_map<std::string, bool> AttributesController::kDefaultAttrib
     {kEdgeCountryCrossing, true},
     {kEdgeForward, true},
     {kEdgeLevels, true},
+    {kEdgeTrafficSignal, true},
 
     // Node keys
     {kIncidents, false},

--- a/src/thor/triplegbuilder.cc
+++ b/src/thor/triplegbuilder.cc
@@ -1220,6 +1220,11 @@ TripLeg_Edge* AddTripEdge(const AttributesController& controller,
     trip_edge->set_forward(directededge->forward());
   }
 
+  // Set traffic signal if requested
+  if (controller(kEdgeTrafficSignal)) {
+    trip_edge->set_traffic_signal(directededge->traffic_signal());
+  }
+
   if (controller(kEdgeLevels)) {
     trip_edge->set_level_precision(std::max(static_cast<uint32_t>(1), levels.second));
     for (const auto& level : levels.first) {

--- a/src/tyr/trace_serializer.cc
+++ b/src/tyr/trace_serializer.cc
@@ -196,6 +196,9 @@ void serialize_edges(const AttributesController& controller,
       if (controller(kEdgeForward)) {
         writer("forward", edge.forward());
       }
+      if (controller(kEdgeTrafficSignal)) {
+        writer("traffic_signal", edge.traffic_signal());
+      }
       if (controller(kEdgeLevels)) {
         if (edge.levels_size()) {
           writer.start_array("levels");

--- a/test/gurka/test_trace_attributes.cc
+++ b/test/gurka/test_trace_attributes.cc
@@ -118,7 +118,7 @@ TEST(Standalone, InterpolatedPoints) {
   ASSERT_EQ(result_doc["matched_points"][5]["edge_index"].GetInt(), 1);
 }
 
-TEST(Standalone, RetrieveTrafficSignal) {
+TEST(Standalone, RetrieveNodeTrafficSignal) {
   const std::string ascii_map = R"(
     A---B---C
         |
@@ -133,7 +133,7 @@ TEST(Standalone, RetrieveTrafficSignal) {
 
   const double gridsize = 10;
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
-  auto map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/traffic_signal_attributes");
+  auto map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/traffic_signal_node_attributes");
 
   std::string trace_json;
   auto api = gurka::do_action(valhalla::Options::trace_attributes, map, {"A", "B", "C"}, "auto", {},
@@ -150,4 +150,39 @@ TEST(Standalone, RetrieveTrafficSignal) {
 
   EXPECT_TRUE(edges[1]["end_node"].HasMember("traffic_signal"));
   EXPECT_FALSE(edges[1]["end_node"]["traffic_signal"].GetBool());
+}
+
+TEST(Standalone, RetrieveEdgeTrafficSignal) {
+  const std::string ascii_map = R"(
+    A--B--C--D
+  )";
+
+  const gurka::ways ways = {
+    {"ABC", {{"highway", "primary"}}},
+    {"CD",  {{"highway", "primary"}}}
+  };
+
+  const gurka::nodes nodes = {
+    {"B", {{"highway", "traffic_signals"}, {"traffic_signals:direction", "forward"}}}
+  };
+
+  const double gridsize = 10;
+  const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
+  auto map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/traffic_signal_edge_attributes");
+
+  std::string trace_json;
+  auto api = gurka::do_action(valhalla::Options::trace_attributes, map, {"A", "B", "C", "D"}, "auto", {},
+                              {}, &trace_json, "via");
+
+  rapidjson::Document result;
+  result.Parse(trace_json.c_str());
+
+  auto edges = result["edges"].GetArray();
+  ASSERT_EQ(edges.Size(), 2);
+
+  EXPECT_TRUE(edges[0].HasMember("traffic_signal"));
+  EXPECT_TRUE(edges[0]["traffic_signal"].GetBool());
+
+  EXPECT_TRUE(edges[1].HasMember("traffic_signal"));
+  EXPECT_FALSE(edges[1]["traffic_signal"].GetBool());
 }

--- a/test/gurka/test_trace_attributes.cc
+++ b/test/gurka/test_trace_attributes.cc
@@ -157,22 +157,18 @@ TEST(Standalone, RetrieveEdgeTrafficSignal) {
     A--B--C--D
   )";
 
-  const gurka::ways ways = {
-    {"ABC", {{"highway", "primary"}}},
-    {"CD",  {{"highway", "primary"}}}
-  };
+  const gurka::ways ways = {{"ABC", {{"highway", "primary"}}}, {"CD", {{"highway", "primary"}}}};
 
   const gurka::nodes nodes = {
-    {"B", {{"highway", "traffic_signals"}, {"traffic_signals:direction", "forward"}}}
-  };
+      {"B", {{"highway", "traffic_signals"}, {"traffic_signals:direction", "forward"}}}};
 
   const double gridsize = 10;
   const auto layout = gurka::detail::map_to_coordinates(ascii_map, gridsize);
   auto map = gurka::buildtiles(layout, ways, nodes, {}, "test/data/traffic_signal_edge_attributes");
 
   std::string trace_json;
-  auto api = gurka::do_action(valhalla::Options::trace_attributes, map, {"A", "B", "C", "D"}, "auto", {},
-                              {}, &trace_json, "via");
+  auto api = gurka::do_action(valhalla::Options::trace_attributes, map, {"A", "B", "C", "D"}, "auto",
+                              {}, {}, &trace_json, "via");
 
   rapidjson::Document result;
   result.Parse(trace_json.c_str());

--- a/valhalla/baldr/attributes_controller.h
+++ b/valhalla/baldr/attributes_controller.h
@@ -81,6 +81,7 @@ const std::string kEdgeLandmarks = "edge.landmarks";
 const std::string kEdgeCountryCrossing = "edge.country_crossing";
 const std::string kEdgeForward = "edge.forward";
 const std::string kEdgeLevels = "edge.levels";
+const std::string kEdgeTrafficSignal = "edge.traffic_sign";
 
 // Node keys
 const std::string kNodeIntersectingEdgeBeginHeading = "node.intersecting_edge.begin_heading";

--- a/valhalla/baldr/attributes_controller.h
+++ b/valhalla/baldr/attributes_controller.h
@@ -81,7 +81,7 @@ const std::string kEdgeLandmarks = "edge.landmarks";
 const std::string kEdgeCountryCrossing = "edge.country_crossing";
 const std::string kEdgeForward = "edge.forward";
 const std::string kEdgeLevels = "edge.levels";
-const std::string kEdgeTrafficSignal = "edge.traffic_sign";
+const std::string kEdgeTrafficSignal = "edge.traffic_signal";
 
 // Node keys
 const std::string kNodeIntersectingEdgeBeginHeading = "node.intersecting_edge.begin_heading";


### PR DESCRIPTION
# Issue

At the moment it is only possible to obtain information about traffic lights on a route via the trace attributes filter `node.traffic_signal`. However, most traffic lights are located on an edge and therefore it makes sense to implement the `edge.traffic_signal` filter.

## Fix

With this pull request we enable the "trace_attributes" endpoint to retrieve information whether there is a traffic signal on an edge or not.

## Tasklist

 - [X] Add tests
 - [X] Update the docs with any new request parameters or changes to behavior described
 - [X] Update the [changelog](CHANGELOG.md)

## Relations

This PR is based on [4876](https://github.com/valhalla/valhalla/pull/4876), the changes are the same.

---

Tim Travica tim.travica@mercedes-benz.com, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under MIT
